### PR TITLE
refactor(charts): template rbac rules for clarity

### DIFF
--- a/charts/pgrator/templates/rbac/role.yaml
+++ b/charts/pgrator/templates/rbac/role.yaml
@@ -31,14 +31,33 @@ rules:
   verbs: [get, patch, update]
 {{- end }}
 
-# Managed resources - child resources created/owned by controllers
-{{- range .Values.rbac.managedResources }}
-- apiGroups:
-  {{- toYaml .apiGroups | nindent 2 }}
-  resources:
-  {{- toYaml .resources | nindent 2 }}
+# Resources needed for Valkey/OpenSearch controllers
+- apiGroups: [aiven.io]
+  resources: [valkeys, opensearches, serviceintegrations]
   verbs: [create, delete, get, list, patch, update, watch]
-{{- end }}
+
+# Resources needed for Postgres controller
+- apiGroups: [acid.zalan.do]
+  resources: [postgresqls]
+  verbs: [create, delete, get, list, patch, update, watch]
+- apiGroups: [iam.cnrm.cloud.google.com]
+  resources: [iampolicymembers, iamserviceaccounts]
+  verbs: [create, delete, get, list, patch, update, watch]
+- apiGroups: [networking.k8s.io]
+  resources: [networkpolicies]
+  verbs: [create, delete, get, list, patch, update, watch]
+- apiGroups: [monitoring.coreos.com]
+  resources: [prometheusrules]
+  verbs: [create, delete, get, list, patch, update, watch]
+- apiGroups: [rbac.authorization.k8s.io]
+  resources: [rolebindings]
+  verbs: [create, get, list, patch, update, watch]
+- apiGroups: [""]
+  resources: [serviceaccounts]
+  verbs: [create, get, list, patch, update, watch]
+- apiGroups: [""]
+  resources: [namespaces]
+  verbs: [get, list, watch]
 
 # Controller runtime requirements
 - apiGroups: [coordination.k8s.io]
@@ -47,11 +66,4 @@ rules:
 - apiGroups: ["", events.k8s.io]
   resources: [events]
   verbs: [create, patch]
-# TODO: these seem to be unused? possibly a remnant from kube-rbac-proxy?
-- apiGroups: [authorization.k8s.io]
-  resources: [subjectaccessreviews]
-  verbs: [create]
-- apiGroups: [authentication.k8s.io]
-  resources: [tokenreviews]
-  verbs: [create]
 {{- end -}}

--- a/charts/pgrator/values.yaml
+++ b/charts/pgrator/values.yaml
@@ -42,36 +42,16 @@ controllerManager:
     enable: true
 
 # [RBAC]: To enable RBAC (Permissions) configurations
-# When adding resources, ensure that you're using the *plural* form of the resource name
 rbac:
   enable: true
   # Primary resources - CRDs owned/reconciled by pgrator (full CRUD)
   # The template auto-generates /finalizers and /status subresource rules
+  # When adding resources, ensure that you're using the *plural* form of the resource name
   primaryResources:
     - apiGroups: [data.nais.io]
       resources: [postgres]
     - apiGroups: [nais.io]
       resources: [valkeys, opensearches]
-
-  # Managed child resources - created/owned by controllers (full CRUD)
-  managedResources:
-    # Valkey/OpenSearch controllers
-    - apiGroups: [aiven.io]
-      resources: [valkeys, opensearches, serviceintegrations]
-    # Postgres controller
-    - apiGroups: [acid.zalan.do]
-      resources: [postgresqls]
-    - apiGroups: [iam.cnrm.cloud.google.com]
-      resources: [iampolicymembers, iamserviceaccounts]
-    - apiGroups: [networking.k8s.io]
-      resources: [networkpolicies]
-    - apiGroups: [monitoring.coreos.com]
-      resources: [prometheusrules]
-    - apiGroups: [rbac.authorization.k8s.io]
-      resources: [rolebindings]
-    # TODO: does pgrator need full CRUD on namespaces or just get/list?
-    - apiGroups: [""]
-      resources: [serviceaccounts, namespaces]
 
 # [METRICS]: Set to true to generate manifests for exporting metrics.
 # To disable metrics export set false, and ensure that the


### PR DESCRIPTION
It's very easy to lose track of the resources, e.g. we've had duplicate rules for quite some time as well as possible unused and unnecessary rules.

Could possibly split them up into multiple roles instead, but we've kept them contained in the same role for now.