### PR TITLE
fix(cnpg): remove shared_preload_libraries from parameters

### DIFF
--- a/internal/controller/engine_test.go
+++ b/internal/controller/engine_test.go
@@ -151,6 +151,141 @@ func TestValidateEngineImmutability(t *testing.T) {
 	}
 }
 
+// TestEngineSelectionAndValidation tests the full engine resolution + validation
+// pipeline as experienced by real users. This is the backward-compat safety net.
+func TestEngineSelectionAndValidation(t *testing.T) {
+	tests := []struct {
+		name         string
+		annotations  map[string]string
+		majorVersion string
+		wantErr      bool
+		errContains  string
+	}{
+		// Backward compatibility: existing users without annotations
+		{
+			name:         "no annotations with v16 defaults to zalando and succeeds",
+			annotations:  nil,
+			majorVersion: "16",
+		},
+		{
+			name:         "no annotations with v17 defaults to zalando and succeeds",
+			annotations:  nil,
+			majorVersion: "17",
+		},
+		{
+			name:         "empty annotations with v16 defaults to zalando and succeeds",
+			annotations:  map[string]string{},
+			majorVersion: "16",
+		},
+		{
+			name:         "empty annotations with v17 defaults to zalando and succeeds",
+			annotations:  map[string]string{},
+			majorVersion: "17",
+		},
+		// Existing user tries v18 without engine annotation (should fail)
+		{
+			name:         "no annotations with v18 defaults to zalando and is rejected",
+			annotations:  nil,
+			majorVersion: "18",
+			wantErr:      true,
+			errContains:  "zalando engine only supports majorVersion 16 or 17",
+		},
+		// Existing zalando user with active-engine set (post first reconcile)
+		{
+			name:         "active-engine zalando with v16 succeeds",
+			annotations:  map[string]string{api.ActiveEngineAnnotation: api.EngineZalando},
+			majorVersion: "16",
+		},
+		{
+			name:         "active-engine zalando with v17 succeeds",
+			annotations:  map[string]string{api.ActiveEngineAnnotation: api.EngineZalando},
+			majorVersion: "17",
+		},
+		{
+			name:         "active-engine zalando with v18 is rejected",
+			annotations:  map[string]string{api.ActiveEngineAnnotation: api.EngineZalando},
+			majorVersion: "18",
+			wantErr:      true,
+			errContains:  "zalando engine only supports majorVersion 16 or 17",
+		},
+		// New CNPG user
+		{
+			name:         "engine cnpg with v18 succeeds",
+			annotations:  map[string]string{api.EngineAnnotation: api.EngineCNPG},
+			majorVersion: "18",
+		},
+		{
+			name:         "engine cnpg with v17 is rejected",
+			annotations:  map[string]string{api.EngineAnnotation: api.EngineCNPG},
+			majorVersion: "17",
+			wantErr:      true,
+			errContains:  "cnpg engine requires majorVersion >= 18",
+		},
+		// Active-engine takes precedence: user annotation overridden
+		{
+			name:         "active-engine zalando overrides engine cnpg annotation",
+			annotations:  map[string]string{api.ActiveEngineAnnotation: api.EngineZalando, api.EngineAnnotation: api.EngineCNPG},
+			majorVersion: "17",
+		},
+		{
+			name:         "active-engine cnpg with v18 succeeds even without engine annotation",
+			annotations:  map[string]string{api.ActiveEngineAnnotation: api.EngineCNPG},
+			majorVersion: "18",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &data_nais_io_v1.Postgres{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tt.annotations,
+				},
+				Spec: data_nais_io_v1.PostgresSpec{
+					Cluster: data_nais_io_v1.PostgresCluster{
+						MajorVersion: tt.majorVersion,
+					},
+				},
+			}
+
+			// Simulate the Prepare() validation pipeline
+			engine, err := getEngine(obj)
+			if err != nil {
+				if !tt.wantErr {
+					t.Fatalf("unexpected getEngine error: %v", err)
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			if err := validateEngineImmutability(obj, engine); err != nil {
+				if !tt.wantErr {
+					t.Fatalf("unexpected immutability error: %v", err)
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			if err := validateVersionForEngine(obj.Spec.Cluster.MajorVersion, engine); err != nil {
+				if !tt.wantErr {
+					t.Fatalf("unexpected version error: %v", err)
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			if tt.wantErr {
+				t.Error("expected error but validation pipeline succeeded")
+			}
+		})
+	}
+}
+
 func TestValidateVersionForEngine(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/internal/controller/resourcecreator/cnpg.go
+++ b/internal/controller/resourcecreator/cnpg.go
@@ -249,7 +249,6 @@ func makeCNPGPostgresParameters(audit *data_nais_io_v1.PostgresAudit, memory res
 	}
 
 	params := map[string]string{
-		"shared_preload_libraries":   "pg_stat_statements,pgaudit",
 		"log_min_duration_statement": "1000",
 		"shared_buffers":             fmt.Sprintf("%dMB", sharedBuffers/(1024*1024)),
 		"effective_cache_size":       fmt.Sprintf("%dMB", effectiveCacheSize/(1024*1024)),
@@ -258,6 +257,10 @@ func makeCNPGPostgresParameters(audit *data_nais_io_v1.PostgresAudit, memory res
 		"random_page_cost":           "1.1",
 		"effective_io_concurrency":   "200",
 		"huge_pages":                 "off",
+		// CNPG auto-manages shared_preload_libraries when it detects these prefixed parameters.
+		// Setting pg_stat_statements.track triggers loading of pg_stat_statements,
+		// and pgaudit.log (set below) triggers loading of pgaudit.
+		"pg_stat_statements.track": "all",
 	}
 
 	if audit != nil && audit.Enabled {


### PR DESCRIPTION
## Problem

CNPG's validating webhook rejects `shared_preload_libraries` set directly in `spec.postgresql.parameters` — it's a fixed/managed configuration parameter:

```
admission webhook "vcluster.cnpg.io" denied the request: spec.postgresql.parameters.shared_preload_libraries: Invalid value: "pg_stat_statements,pgaudit": Can't set fixed configuration parameter
```

## Fix

Remove the explicit `shared_preload_libraries` parameter and rely on CNPG's [managed extensions](https://cloudnative-pg.io/docs/devel/postgresql_conf/#managed-extensions) feature instead. When CNPG detects prefixed parameters like `pg_stat_statements.track` or `pgaudit.log`, it automatically adds the corresponding library to `shared_preload_libraries`.

Also adds `TestEngineSelectionAndValidation` — an integration-style test covering the full engine resolution + version validation pipeline for backward-compat scenarios (existing users without annotations, active-engine precedence, etc.).