### PR TITLE
feat(cnpg): add WAL, checkpoint and monitoring parameters

### DIFF
--- a/internal/controller/resourcecreator/cnpg.go
+++ b/internal/controller/resourcecreator/cnpg.go
@@ -238,7 +238,7 @@ func MinimalCNPGPooler(postgres *data_nais_io_v1.Postgres, clusterName, namespac
 
 func makeCNPGPostgresParameters(cluster data_nais_io_v1.PostgresCluster) map[string]string {
 	memBytes := cluster.Resources.Memory.Value()
-	diskBytes := cluster.Resources.DiskSize.Value()
+	diskBytes := enforceMinimum2GiDisk(cluster.Resources.DiskSize).Value()
 
 	// PostgreSQL memory tuning parameters based on available memory
 	sharedBuffers := memBytes / sharedBuffersFraction

--- a/internal/controller/resourcecreator/cnpg.go
+++ b/internal/controller/resourcecreator/cnpg.go
@@ -91,7 +91,7 @@ func CreateCNPGClusterSpec(postgres *data_nais_io_v1.Postgres, cfg *config.Confi
 		},
 
 		PostgresConfiguration: cnpgv1.PostgresConfiguration{
-			Parameters: makeCNPGPostgresParameters(postgres.Spec.Cluster.Audit, postgres.Spec.Cluster.Resources.Memory),
+			Parameters: makeCNPGPostgresParameters(postgres.Spec.Cluster),
 		},
 
 		Bootstrap: &cnpgv1.BootstrapConfiguration{
@@ -236,10 +236,11 @@ func MinimalCNPGPooler(postgres *data_nais_io_v1.Postgres, clusterName, namespac
 	}
 }
 
-func makeCNPGPostgresParameters(audit *data_nais_io_v1.PostgresAudit, memory resource.Quantity) map[string]string {
-	memBytes := memory.Value()
+func makeCNPGPostgresParameters(cluster data_nais_io_v1.PostgresCluster) map[string]string {
+	memBytes := cluster.Resources.Memory.Value()
+	diskBytes := cluster.Resources.DiskSize.Value()
 
-	// PostgreSQL tuning parameters based on available memory
+	// PostgreSQL memory tuning parameters based on available memory
 	sharedBuffers := memBytes / sharedBuffersFraction
 	effectiveCacheSize := memBytes * 3 / effectiveCacheSizeFraction
 	workMem := memBytes / workMemFraction
@@ -248,24 +249,64 @@ func makeCNPGPostgresParameters(audit *data_nais_io_v1.PostgresAudit, memory res
 		maintenanceWorkMem = maxMaintenanceWorkMemBytes
 	}
 
+	// WAL sizing: ~2% of disk, clamped between 1GB and 8GB
+	maxWalSize := diskBytes / 50
+	if maxWalSize < 1*1024*1024*1024 {
+		maxWalSize = 1 * 1024 * 1024 * 1024
+	}
+	if maxWalSize > 8*1024*1024*1024 {
+		maxWalSize = 8 * 1024 * 1024 * 1024
+	}
+
+	// wal_buffers: 1/32 of shared_buffers, clamped to 64MB (PostgreSQL max useful)
+	walBuffers := sharedBuffers / 32
+	if walBuffers < 1*1024*1024 {
+		walBuffers = 1 * 1024 * 1024
+	}
+	if walBuffers > 64*1024*1024 {
+		walBuffers = 64 * 1024 * 1024
+	}
+
 	params := map[string]string{
+		// Memory
+		"shared_buffers":       fmt.Sprintf("%dMB", sharedBuffers/(1024*1024)),
+		"effective_cache_size": fmt.Sprintf("%dMB", effectiveCacheSize/(1024*1024)),
+		"work_mem":             fmt.Sprintf("%dMB", workMem/(1024*1024)),
+		"maintenance_work_mem": fmt.Sprintf("%dMB", maintenanceWorkMem/(1024*1024)),
+		"huge_pages":           "off",
+
+		// WAL performance
+		"max_wal_size":    fmt.Sprintf("%dMB", maxWalSize/(1024*1024)),
+		"wal_compression": "zstd",
+		"wal_buffers":     fmt.Sprintf("%dMB", walBuffers/(1024*1024)),
+
+		// Checkpoint / background writer
+		"checkpoint_timeout":    "10min",
+		"bgwriter_lru_maxpages": "200",
+
+		// I/O tuning for SSD
+		"effective_io_concurrency": "200",
+		"random_page_cost":         "1.1",
+
+		// Monitoring
+		"track_io_timing":            "on",
 		"log_min_duration_statement": "1000",
-		"shared_buffers":             fmt.Sprintf("%dMB", sharedBuffers/(1024*1024)),
-		"effective_cache_size":       fmt.Sprintf("%dMB", effectiveCacheSize/(1024*1024)),
-		"work_mem":                   fmt.Sprintf("%dMB", workMem/(1024*1024)),
-		"maintenance_work_mem":       fmt.Sprintf("%dMB", maintenanceWorkMem/(1024*1024)),
-		"random_page_cost":           "1.1",
-		"effective_io_concurrency":   "200",
-		"huge_pages":                 "off",
+
 		// CNPG auto-manages shared_preload_libraries when it detects these prefixed parameters.
 		// Setting pg_stat_statements.track triggers loading of pg_stat_statements,
 		// and pgaudit.log (set below) triggers loading of pgaudit.
 		"pg_stat_statements.track": "all",
 	}
 
-	if audit != nil && audit.Enabled {
-		classes := make([]string, 0, len(audit.StatementClasses))
-		for _, c := range audit.StatementClasses {
+	// Group commit reduces sync-rep round trips in HA clusters
+	if cluster.HighAvailability {
+		params["commit_delay"] = "100"
+		params["commit_siblings"] = "10"
+	}
+
+	if cluster.Audit != nil && cluster.Audit.Enabled {
+		classes := make([]string, 0, len(cluster.Audit.StatementClasses))
+		for _, c := range cluster.Audit.StatementClasses {
 			classes = append(classes, string(c))
 		}
 		params["pgaudit.log"] = strings.Join(classes, ",")

--- a/tests/e2e/postgres-cnpg-basic/chainsaw-test.yaml
+++ b/tests/e2e/postgres-cnpg-basic/chainsaw-test.yaml
@@ -15,12 +15,6 @@ spec:
                 name: cnpg-team
                 labels:
                   google-cloud-project: test-project
-        - apply:
-            resource:
-              apiVersion: v1
-              kind: Namespace
-              metadata:
-                name: pg-cnpg-team
     - name: Create Postgres resource
       try:
         - apply:
@@ -48,7 +42,7 @@ spec:
               kind: Cluster
               metadata:
                 name: mydb
-                namespace: pg-cnpg-team
+                namespace: cnpg-team
     - name: Assert CNPG Pooler created
       try:
         - assert:
@@ -57,7 +51,7 @@ spec:
               kind: Pooler
               metadata:
                 name: mydb-pooler
-                namespace: pg-cnpg-team
+                namespace: cnpg-team
     - name: Assert ServiceAccount created
       try:
         - assert:
@@ -66,7 +60,7 @@ spec:
               kind: ServiceAccount
               metadata:
                 name: postgres-pod
-                namespace: pg-cnpg-team
+                namespace: cnpg-team
     - name: Assert NetworkPolicy created
       try:
         - assert:
@@ -75,7 +69,7 @@ spec:
               kind: NetworkPolicy
               metadata:
                 name: mydb
-                namespace: pg-cnpg-team
+                namespace: cnpg-team
     - name: Assert PodMonitor created
       try:
         - assert:
@@ -83,8 +77,8 @@ spec:
               apiVersion: monitoring.coreos.com/v1
               kind: PodMonitor
               metadata:
-                name: mydb
-                namespace: pg-cnpg-team
+                name: pg-mydb
+                namespace: cnpg-team
                 labels:
                   prometheus: tenant
               spec:
@@ -100,8 +94,8 @@ spec:
               apiVersion: monitoring.coreos.com/v1
               kind: PrometheusRule
               metadata:
-                name: mydb
-                namespace: pg-cnpg-team
+                name: pg-mydb
+                namespace: cnpg-team
     - name: Assert engine annotation set
       try:
         - assert:

--- a/tests/e2e/postgres-cnpg-basic/chainsaw-test.yaml
+++ b/tests/e2e/postgres-cnpg-basic/chainsaw-test.yaml
@@ -76,6 +76,32 @@ spec:
               metadata:
                 name: mydb
                 namespace: pg-cnpg-team
+    - name: Assert PodMonitor created
+      try:
+        - assert:
+            resource:
+              apiVersion: monitoring.coreos.com/v1
+              kind: PodMonitor
+              metadata:
+                name: mydb
+                namespace: pg-cnpg-team
+                labels:
+                  prometheus: tenant
+              spec:
+                selector:
+                  matchLabels:
+                    cnpg.io/cluster: mydb
+                podMetricsEndpoints:
+                  - port: metrics
+    - name: Assert PrometheusRule created
+      try:
+        - assert:
+            resource:
+              apiVersion: monitoring.coreos.com/v1
+              kind: PrometheusRule
+              metadata:
+                name: mydb
+                namespace: pg-cnpg-team
     - name: Assert engine annotation set
       try:
         - assert:


### PR DESCRIPTION
Expand CNPG PostgreSQL tuning based on upstream best practices:

- WAL: max_wal_size (2% of disk, 1-8GB), wal_compression=zstd,
  wal_buffers (1/32 of shared_buffers)
- Checkpoints: checkpoint_timeout=10min, bgwriter_lru_maxpages=200
- Monitoring: track_io_timing=on, pg_stat_statements.track=all
- HA-only: commit_delay/commit_siblings for group commit
- Remove shared_preload_libraries (CNPG manages it automatically)

All dynamic values are computed from cluster shape (memory, disk,
highAvailability) — no hardcoded sizes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
