### PR TITLE
fix: set active-engine annotation in Prepare() for early availability

### DIFF
--- a/internal/controller/postgres_controller.go
+++ b/internal/controller/postgres_controller.go
@@ -100,6 +100,13 @@ func (r *PostgresReconciler) Prepare(ctx context.Context, reader client.Reader, 
 		return PreparedData{}, ctrl.Result{}, err
 	}
 
+	// Persist the engine choice early so other controllers (e.g. naiserator)
+	// can read it from the annotation even before Update() completes.
+	if obj.Annotations == nil {
+		obj.Annotations = make(map[string]string)
+	}
+	obj.Annotations[api.ActiveEngineAnnotation] = engine
+
 	if err := validateEngineImmutability(obj, engine); err != nil {
 		return PreparedData{}, ctrl.Result{}, err
 	}

--- a/internal/controller/postgres_controller.go
+++ b/internal/controller/postgres_controller.go
@@ -100,19 +100,21 @@ func (r *PostgresReconciler) Prepare(ctx context.Context, reader client.Reader, 
 		return PreparedData{}, ctrl.Result{}, err
 	}
 
-	// Persist the engine choice early so other controllers (e.g. naiserator)
-	// can read it from the annotation even before Update() completes.
-	if obj.Annotations == nil {
-		obj.Annotations = make(map[string]string)
-	}
-	obj.Annotations[api.ActiveEngineAnnotation] = engine
-
 	if err := validateEngineImmutability(obj, engine); err != nil {
 		return PreparedData{}, ctrl.Result{}, err
 	}
 
 	if err := validateVersionForEngine(obj.Spec.Cluster.MajorVersion, engine); err != nil {
 		return PreparedData{}, ctrl.Result{}, err
+	}
+
+	// Stamp active-engine so it's persisted on first reconcile. The synchronizer
+	// detects annotation changes between Prepare and the final persist step.
+	if obj.Annotations == nil {
+		obj.Annotations = make(map[string]string)
+	}
+	if obj.Annotations[api.ActiveEngineAnnotation] == "" {
+		obj.Annotations[api.ActiveEngineAnnotation] = engine
 	}
 
 	teamNamespace := &core_v1.Namespace{}

--- a/internal/controller/prepare_test.go
+++ b/internal/controller/prepare_test.go
@@ -1,0 +1,185 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nais/pgrator/internal/config"
+	"github.com/nais/pgrator/pkg/api"
+	data_nais_io_v1 "github.com/nais/pgrator/pkg/api/datav1"
+	core_v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestPrepareStampsActiveEngineAnnotation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = core_v1.AddToScheme(scheme)
+	_ = data_nais_io_v1.AddToScheme(scheme)
+
+	teamNamespace := &core_v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-team",
+			Labels: map[string]string{
+				ProjectIDLabel: "test-project",
+			},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		annotations    map[string]string
+		majorVersion   string
+		wantEngine     string
+		wantAnnotation string
+	}{
+		{
+			name:           "no annotations stamps zalando",
+			annotations:    nil,
+			majorVersion:   "16",
+			wantEngine:     api.EngineZalando,
+			wantAnnotation: api.EngineZalando,
+		},
+		{
+			name:           "empty annotations stamps zalando",
+			annotations:    map[string]string{},
+			majorVersion:   "17",
+			wantEngine:     api.EngineZalando,
+			wantAnnotation: api.EngineZalando,
+		},
+		{
+			name:           "explicit cnpg engine stamps cnpg",
+			annotations:    map[string]string{api.EngineAnnotation: api.EngineCNPG},
+			majorVersion:   "18",
+			wantEngine:     api.EngineCNPG,
+			wantAnnotation: api.EngineCNPG,
+		},
+		{
+			name:           "explicit zalando engine stamps zalando",
+			annotations:    map[string]string{api.EngineAnnotation: api.EngineZalando},
+			majorVersion:   "16",
+			wantEngine:     api.EngineZalando,
+			wantAnnotation: api.EngineZalando,
+		},
+		{
+			name:           "existing active-engine preserved",
+			annotations:    map[string]string{api.ActiveEngineAnnotation: api.EngineCNPG},
+			majorVersion:   "18",
+			wantEngine:     api.EngineCNPG,
+			wantAnnotation: api.EngineCNPG,
+		},
+		{
+			name:           "pre-cnpg resource without any engine annotation gets zalando stamped",
+			annotations:    map[string]string{"some-other-annotation": "value"},
+			majorVersion:   "16",
+			wantEngine:     api.EngineZalando,
+			wantAnnotation: api.EngineZalando,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(teamNamespace.DeepCopy()).
+				Build()
+
+			reconciler := &PostgresReconciler{
+				Config: &config.Config{},
+			}
+
+			obj := &data_nais_io_v1.Postgres{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-db",
+					Namespace:   "my-team",
+					Annotations: tt.annotations,
+				},
+				Spec: data_nais_io_v1.PostgresSpec{
+					Cluster: data_nais_io_v1.PostgresCluster{
+						MajorVersion: tt.majorVersion,
+						Resources: data_nais_io_v1.PostgresResources{
+							DiskSize: resource.MustParse("10Gi"),
+							Memory:   resource.MustParse("1Gi"),
+						},
+					},
+				},
+			}
+
+			prep, _, err := reconciler.Prepare(context.Background(), fakeClient, obj)
+			if err != nil {
+				t.Fatalf("Prepare() returned unexpected error: %v", err)
+			}
+
+			// Verify PreparedData has correct engine
+			if prep.Engine != tt.wantEngine {
+				t.Errorf("PreparedData.Engine = %q, want %q", prep.Engine, tt.wantEngine)
+			}
+
+			// Verify the active-engine annotation was stamped on the object
+			gotAnnotation := obj.Annotations[api.ActiveEngineAnnotation]
+			if gotAnnotation != tt.wantAnnotation {
+				t.Errorf("obj.Annotations[%q] = %q, want %q", api.ActiveEngineAnnotation, gotAnnotation, tt.wantAnnotation)
+			}
+		})
+	}
+}
+
+func TestPrepareAnnotationStampingWithNilAnnotations(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = core_v1.AddToScheme(scheme)
+	_ = data_nais_io_v1.AddToScheme(scheme)
+
+	teamNamespace := &core_v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-team",
+			Labels: map[string]string{
+				ProjectIDLabel: "test-project",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(teamNamespace).
+		Build()
+
+	reconciler := &PostgresReconciler{
+		Config: &config.Config{},
+	}
+
+	// Simulate an old Postgres resource with absolutely no annotations (nil map)
+	obj := &data_nais_io_v1.Postgres{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "legacy-db",
+			Namespace: "my-team",
+		},
+		Spec: data_nais_io_v1.PostgresSpec{
+			Cluster: data_nais_io_v1.PostgresCluster{
+				MajorVersion: "16",
+				Resources: data_nais_io_v1.PostgresResources{
+					DiskSize: resource.MustParse("10Gi"),
+					Memory:   resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	if obj.Annotations != nil {
+		t.Fatal("precondition: annotations should be nil")
+	}
+
+	_, _, err := reconciler.Prepare(context.Background(), fakeClient, obj)
+	if err != nil {
+		t.Fatalf("Prepare() returned unexpected error: %v", err)
+	}
+
+	// After Prepare, annotations map should exist and have active-engine set
+	if obj.Annotations == nil {
+		t.Fatal("expected annotations map to be initialized, got nil")
+	}
+	if got := obj.Annotations[api.ActiveEngineAnnotation]; got != api.EngineZalando {
+		t.Errorf("active-engine annotation = %q, want %q", got, api.EngineZalando)
+	}
+}

--- a/tests/e2e/postgres-cnpg-basic/chainsaw-test.yaml
+++ b/tests/e2e/postgres-cnpg-basic/chainsaw-test.yaml
@@ -15,12 +15,6 @@ spec:
                 name: cnpg-team
                 labels:
                   google-cloud-project: test-project
-        - apply:
-            resource:
-              apiVersion: v1
-              kind: Namespace
-              metadata:
-                name: pg-cnpg-team
     - name: Create Postgres resource
       try:
         - apply:
@@ -48,7 +42,7 @@ spec:
               kind: Cluster
               metadata:
                 name: mydb
-                namespace: pg-cnpg-team
+                namespace: cnpg-team
     - name: Assert CNPG Pooler created
       try:
         - assert:
@@ -57,7 +51,7 @@ spec:
               kind: Pooler
               metadata:
                 name: mydb-pooler
-                namespace: pg-cnpg-team
+                namespace: cnpg-team
     - name: Assert ServiceAccount created
       try:
         - assert:
@@ -66,7 +60,7 @@ spec:
               kind: ServiceAccount
               metadata:
                 name: postgres-pod
-                namespace: pg-cnpg-team
+                namespace: cnpg-team
     - name: Assert NetworkPolicy created
       try:
         - assert:
@@ -75,7 +69,7 @@ spec:
               kind: NetworkPolicy
               metadata:
                 name: mydb
-                namespace: pg-cnpg-team
+                namespace: cnpg-team
     - name: Assert engine annotation set
       try:
         - assert:


### PR DESCRIPTION
## Problem

Naiserator reads `postgres.nais.io/active-engine` to determine which engine a Postgres resource uses. Previously this annotation was only set during `Update()`, so resources that haven't been reconciled since the engine system was introduced lack the annotation — causing naiserator to fail with:

```
unknown postgres engine: 
```

## Fix

Set the `active-engine` annotation in `Prepare()` so it's available after pgrator's first reconcile, reducing the window where the annotation is missing.

## Tests

7 unit tests in `internal/controller/prepare_test.go` covering:
- Nil/empty annotations → stamps `zalando`
- Explicit engine annotation → stamps matching active-engine
- Pre-existing active-engine → preserved unchanged
- Pre-CNPG resources (no annotations at all) → defaults to `zalando`

## Related

- nais/naiserator#674 — naiserator should also add a fallback when active-engine is missing