### PR TITLE
fix: persist annotations even when Prepare() fails

### DIFF
--- a/internal/synchronizer/synchronizer.go
+++ b/internal/synchronizer/synchronizer.go
@@ -151,6 +151,7 @@ func (s *Synchronizer[T, P]) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	s.recorder.RecordEvent(obj, core_v1.EventTypeNormal, "Preparing", "Preparing resources")
 
+	prePrepareObj := obj.DeepCopyObject().(client.Object)
 	prep, result, err := s.reconciler.Prepare(ctx, s.client, obj)
 	if err != nil {
 		logger.Error(err, "failed preparation stage")
@@ -160,8 +161,11 @@ func (s *Synchronizer[T, P]) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 		// Persist annotation changes even on Prepare failure so that annotations
 		// stamped early (e.g. active-engine) are saved to the API server.
+		// Use MergePatch from the pre-Prepare snapshot to avoid accidentally
+		// persisting other object mutations made during Prepare().
 		if !maps.Equal(originalAnnotations, obj.GetAnnotations()) {
-			if updateErr := s.client.Update(ctx, obj); updateErr != nil {
+			patch := client.MergeFrom(prePrepareObj)
+			if updateErr := s.client.Patch(ctx, obj, patch); updateErr != nil {
 				logger.Error(updateErr, "failed to persist annotations after Prepare error")
 			}
 		}

--- a/internal/synchronizer/synchronizer.go
+++ b/internal/synchronizer/synchronizer.go
@@ -157,6 +157,15 @@ func (s *Synchronizer[T, P]) Reconcile(ctx context.Context, req ctrl.Request) (c
 		s.recorder.RecordErrorEvent(obj, "Preparing", err)
 		metrics.IncReconcileError(resourceType, obj.GetNamespace(), "Preparing")
 		metrics.ObserveReconcileDuration(resourceType, "error", time.Since(startTime))
+
+		// Persist annotation changes even on Prepare failure so that annotations
+		// stamped early (e.g. active-engine) are saved to the API server.
+		if !maps.Equal(originalAnnotations, obj.GetAnnotations()) {
+			if updateErr := s.client.Update(ctx, obj); updateErr != nil {
+				logger.Error(updateErr, "failed to persist annotations after Prepare error")
+			}
+		}
+
 		return result, err
 	}
 


### PR DESCRIPTION
## Problem

When pgrator's `Prepare()` stamps the `active-engine` annotation but then fails (e.g., namespace missing `google-cloud-project` label), the error path returns early without persisting the annotation. This leaves a broken cycle:

1. pgrator reconciles → stamps annotation in memory → Prepare fails → annotation lost
2. naiserator reads Postgres CR → no `active-engine` → returns "waiting for pgrator..." error
3. naiserator retries in 30 minutes → same result

The user sees: `FailedPrepare: waiting for pgrator to set active-engine annotation on ssbno/statreg-api-test-db; will retry`

## Fix

Persist annotation changes in the synchronizer's Prepare error path. Now even if Prepare fails, the `active-engine` annotation is saved to the API server — breaking the cycle.

## Related

- #96 — set active-engine in Prepare() (merged)
- nais/naiserator#674 — naiserator should also add a Watches on Postgres CRs to immediately re-reconcile when annotation appears (instead of 30-min timer)